### PR TITLE
Fix unneeded m4 include

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,6 @@
 SUBDIRS = src innoSetup debian
 
 # M4
-ACLOCAL_AMFLAGS = -I m4
 
 ## Pour fichier COPYING
 pkgdocdir=$(prefix)


### PR DESCRIPTION
.keep file is needed because Git doesn't allow empty folders. This fixes issue #117.