### PR TITLE
Added check for files bigger than 4GB

### DIFF
--- a/src/woeusb
+++ b/src/woeusb
@@ -272,6 +272,11 @@ init(){
 		exit 1
 	fi
 
+	if [ "${target_filesystem_type}" == 'FAT' ]; then
+		check_for_big_files\
+		"${source_fs_mountpoint}"
+	fi
+
 	if ! mount_target_filesystem\
 		"${target_partition}"\
 		"${target_fs_mountpoint}"\
@@ -2003,6 +2008,19 @@ util_check_function_parameters_quantity(){
 	fi
 	return 0
 }; declare -fr util_check_function_parameters_quantity
+
+##Check every file in source directory for files bigger than max fat32 file size (~4GB)
+check_for_big_files(){
+	local source_fs_mountpoint="${1}"
+
+	for i in $(find ${source_fs_mountpoint}/ -type f); do
+		if (( $(du $i | cut -f -1) > 4194303 )); then
+			echo_with_color red "Error: File $i is larger than that supported by the fat32 filesystem. Use NTFS (--target-filesystem NTFS)."
+			exit 1
+		fi
+	done
+	return 0
+}; declare -fr check_for_big_files
 
 trap trap_exit EXIT
 trap trap_errexit ERR

--- a/src/woeusb
+++ b/src/woeusb
@@ -2014,14 +2014,19 @@ util_check_function_parameters_quantity(){
 ## Check every file in source directory for files bigger than max fat32 file size (~4GB)
 check_for_big_files(){
 	local -r source_fs_mountpoint="${1}"
+	local IFS_backup=$IFS
 
 	IFS=$'\n'
 	for file in ` find "${source_fs_mountpoint}" -type f `; do
 		if (( $(stat -c "%s" $file) > 4294967295 )); then # Max fat32 file size is 2^32 - 1 bytes
 			echo_with_color red "Error: File $file is larger than that supported by the fat32 filesystem. Use NTFS (--target-filesystem NTFS)."
+			IFS=$IFS_backup
+			unset IFS_backup
 			return 1
 		fi
 	done
+	IFS=$IFS_backup
+	unset IFS_backup
 	return 0
 }; declare -fr check_for_big_files
 

--- a/src/woeusb
+++ b/src/woeusb
@@ -273,8 +273,10 @@ init(){
 	fi
 
 	if [ "${target_filesystem_type}" == 'FAT' ]; then
-		check_for_big_files\
-		"${source_fs_mountpoint}"
+		if ! check_for_big_files\
+				"${source_fs_mountpoint}"; then
+			exit 1
+		fi
 	fi
 
 	if ! mount_target_filesystem\
@@ -2009,14 +2011,14 @@ util_check_function_parameters_quantity(){
 	return 0
 }; declare -fr util_check_function_parameters_quantity
 
-##Check every file in source directory for files bigger than max fat32 file size (~4GB)
+## Check every file in source directory for files bigger than max fat32 file size (~4GB)
 check_for_big_files(){
-	local source_fs_mountpoint="${1}"
+	local -r source_fs_mountpoint="${1}"
 
-	for i in $(find ${source_fs_mountpoint}/ -type f); do
-		if (( $(stat -c "%s" $i) > 4294967295 )); then
-			echo_with_color red "Error: File $i is larger than that supported by the fat32 filesystem. Use NTFS (--target-filesystem NTFS)."
-			exit 1
+	for file in $(find "${source_fs_mountpoint}" -type f); do
+		if (( $(stat -c "%s" $file) > 4294967295 )); then # Max fat32 file size is 2^32 - 1 bytes
+			echo_with_color red "Error: File $file is larger than that supported by the fat32 filesystem. Use NTFS (--target-filesystem NTFS)."
+			return 1
 		fi
 	done
 	return 0

--- a/src/woeusb
+++ b/src/woeusb
@@ -2015,7 +2015,8 @@ util_check_function_parameters_quantity(){
 check_for_big_files(){
 	local -r source_fs_mountpoint="${1}"
 
-	for file in $(find "${source_fs_mountpoint}" -type f); do
+	IFS=$'\n'
+	for file in ` find "${source_fs_mountpoint}" -type f `; do
 		if (( $(stat -c "%s" $file) > 4294967295 )); then # Max fat32 file size is 2^32 - 1 bytes
 			echo_with_color red "Error: File $file is larger than that supported by the fat32 filesystem. Use NTFS (--target-filesystem NTFS)."
 			return 1

--- a/src/woeusb
+++ b/src/woeusb
@@ -2014,7 +2014,7 @@ check_for_big_files(){
 	local source_fs_mountpoint="${1}"
 
 	for i in $(find ${source_fs_mountpoint}/ -type f); do
-		if (( $(du $i | cut -f -1) > 4194303 )); then
+		if (( $(stat -c "%s" $i) > 4294967295 )); then
 			echo_with_color red "Error: File $i is larger than that supported by the fat32 filesystem. Use NTFS (--target-filesystem NTFS)."
 			exit 1
 		fi


### PR DESCRIPTION
If source directory contain file with size grater than 4GB, script will end with message:

> Error: File <file> is larger than that supported by the fat32 filesystem. Use NTFS (--target-filesystem NTFS).