### PR TITLE
Update check for passing --device & --partition

### DIFF
--- a/src/woeusb
+++ b/src/woeusb
@@ -605,7 +605,7 @@ process_commandline_parameters(){
 			"${FUNCNAME[0]}: Error: No creation method specified!" >&2
 		return 1
 	elif \
-		[ "${enable_device}" == false ]  \
+		[ "${enable_device}" == true ]  \
 		&& [ "${enable_partition}" == true ]; then
 		echo_with_color red "${FUNCNAME[0]}: Error: --device and --partition creation method are mutual-exclusive." >&2
 		return 1


### PR DESCRIPTION
This seems intended to prevent someone from passing both --device and --partition arguments on the cli.. but the way it's currently written if one were to pass --partition, the tool would fail due to "mutual exclusivity" despite NOT having passed the --device argument

Apologies, if I've misunderstood how this works.. but I edited my copy and was able to successfully boot from a partition, whereas before I got this error message.