### PR TITLE
Extra Information for Gentoousers

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ $ sudo dnf install wxGTK3-devel
 
 # For Fedora 22
 $ sudo dnf install wxGTK-devel dh-autoreconf.noarch
+
+# For Gentoo
+# The Kernel has to be compiled with both CONFIG_UDF_FS and CONFIG_UDF_NLS set to y
 ```
 #### Build & Install WoeUSB
 ```shell


### PR DESCRIPTION
Using woeusbgui it doesnt log any problems but is not able copying the data without both kernel flags for udf (Universal Disk Format, used for all official windows isos) set so I guess it would be helpful for most people to have that information.
Im sorry if I have misplaced it within the README.md but that seems the proper spot to me.

Thanks in advance

EDIT: For obvious reasons it occurs with both the ebuild and compiled from source from upstream