### PR TITLE
Add ability to automatically split install.wim if needed

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,6 +25,7 @@ Depends: bash (>=4.3),
          policykit-1,
          realpath | coreutils (>= 8.23),
          wget,
+         wimtools,
          ${misc:Depends},
          ${shlibs:Depends}
 Description: Bootable Windows installation/PE USB storage creator

--- a/src/woeusb
+++ b/src/woeusb
@@ -1205,6 +1205,12 @@ check_fat32_filesize_limitation(){
 
 	while IFS= read -r -d '' file; do
 		if (( "$(stat -c '%s' "${file}")" > 4294967295 )); then # Max fat32 file size is 2^32 - 1 bytes
+      if [[ "${file}" == */install.wim ]]; then
+        printf_with_color \
+          yellow \
+          'Detected large "install.wim", will try to split it in multiple chunks\n'
+        continue
+      fi
 			printf_with_color \
 				red \
 				'Error: File "%s" in source image has exceed the FAT32 Filesystem 4GiB Single File Size Limitation and cannot be installed.  You must specify a different --target-filesystem.\n' \
@@ -1457,15 +1463,20 @@ copy_filesystem_files(){
 			if [ "${verbose}" = true ]; then
 				echo -e "\\nINFO: Copying \"${source_file}\"..."
 			fi
-			if [ "${source_file_size}" -lt "${DD_BLOCK_SIZE}" ]; then
-				cp "${source_file}" "${dest_file}"
-			else
-				copy_large_file \
-					"${source_file}" \
-					"${dest_file}" \
-					"${copied_size}" \
-					"${total_size}"
-			fi
+      if [[ "${source_file}" == */install.wim ]]; then
+        echo -e "\\nSplitting large install.wim image"
+        wimsplit "${source_file}" "$(echo "${dest_file}" | sed 's/install.wim$/install.swm/g')" 3800
+      else
+  			if [ "${source_file_size}" -lt "${DD_BLOCK_SIZE}" ]; then
+	  			cp "${source_file}" "${dest_file}"
+		  	else
+			  	copy_large_file \
+				  	"${source_file}" \
+					  "${dest_file}" \
+					  "${copied_size}" \
+					  "${total_size}"
+			  fi
+      fi
 		else
 			echo_with_color red "${FUNCNAME[0]}: Error: Unknown type of '${source_file}'!" >&2
 			exit 1

--- a/src/woeusb
+++ b/src/woeusb
@@ -1463,7 +1463,7 @@ copy_filesystem_files(){
 			if [ "${verbose}" = true ]; then
 				echo -e "\\nINFO: Copying \"${source_file}\"..."
 			fi
-      if [[ "${source_file}" == */install.wim ]]; then
+      if [ "$source_file_size" -gt 4294967295 ] && [[ "${source_file}" == */install.wim ]]; then
         echo -e "\\nSplitting large install.wim image"
         wimsplit "${source_file}" "$(echo "${dest_file}" | sed 's/install.wim$/install.swm/g')" 3800
       else


### PR DESCRIPTION
Relevant information:
- https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/install-windows-from-a-usb-flash-drive#troubleshooting-file-copy-fails
- https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/split-a-windows-image--wim--file-to-span-across-multiple-dvds#usb-deployment
- https://github.com/EtchDroid/EtchDroid/issues/5

We know FAT32 filesystem have a very low file size limit, but apparently Windows has supported this condition for very long.

WIM images can be split with `Dism` on Windows; for everyone else [wimlib](https://wimlib.net/) can replace it.

I added the code to split the image only if it's too large. Let me know if I should change anything :)
I also added `wimtools` as a dependency for the Debian package.
