### PR TITLE
Fix issue 272 - error when echo 0 into dirty_background_bytes and dirty_bytes

### DIFF
--- a/src/woeusb
+++ b/src/woeusb
@@ -1674,8 +1674,9 @@ workaround_linux_make_writeback_buffering_not_suck(){
 			echo_with_color \
 				yellow \
 				'Resetting workaround to prevent 64-bit systems with big primary memory from being unresponsive during copying files.'
-			echo 0 > /proc/sys/vm/dirty_background_bytes
-			echo 0 > /proc/sys/vm/dirty_bytes
+
+			{ echo 0 > /proc/sys/vm/dirty_background_bytes; } || { echo_with_color yellow 'Warning!: command "echo 0 > /proc/sys/vm/dirty_background_bytes" - returned code  $?'; }
+			{ echo 0 > /proc/sys/vm/dirty_bytes; } || { echo_with_color yellow 'Warning: command "echo 0 > /proc/sys/vm/dirty_bytes" - returned code  $?'; }
 		;;
 		*)
 			printf_with_color \


### PR DESCRIPTION
When 
`    echo 0 > /proc/sys/vm/dirty_background_bytes`
or
`    echo 0 > /proc/sys/vm/dirty_bytes`
failed and return 1 (file was probably locked because it existed and was writable) then woeusb crashed with message 'program is prematurely aborted' but everything works. 
