### PR TITLE
woeusb: Fix mount error (#299)

### DIFF
--- a/src/woeusb
+++ b/src/woeusb
@@ -1367,7 +1367,7 @@ mount_target_filesystem(){
 
 	mount \
 		--options "${mount_options}" \
-		"${fstype_options}" \
+		${fstype_options} \
 		"${target_partition}" \
 		"${target_fs_mountpoint}" \
 		|| (


### PR DESCRIPTION
The fstype_options variable can contain several options, and thus
should not be quoted.

Closes #299

Signed-off-by: Chris Halls <halls@debian.org>