### PR TITLE
fix echo error

### DIFF
--- a/src/woeusb
+++ b/src/woeusb
@@ -1680,8 +1680,8 @@ workaround_linux_make_writeback_buffering_not_suck(){
 				yellow \
 				'Resetting workaround to prevent 64-bit systems with big primary memory from being unresponsive during copying files.'
 
-			{ echo 0 > /proc/sys/vm/dirty_background_bytes; } || { echo_with_color yellow 'Warning!: command "echo 0 > /proc/sys/vm/dirty_background_bytes" - returned code  $?'; }
-			{ echo 0 > /proc/sys/vm/dirty_bytes; } || { echo_with_color yellow 'Warning: command "echo 0 > /proc/sys/vm/dirty_bytes" - returned code  $?'; }
+			#{ echo 0 > /proc/sys/vm/dirty_background_bytes; } || { echo_with_color yellow 'Warning!: command "echo 0 > /proc/sys/vm/dirty_background_bytes" - returned code  $?'; }
+			#{ echo 0 > /proc/sys/vm/dirty_bytes; } || { echo_with_color yellow 'Warning: command "echo 0 > /proc/sys/vm/dirty_bytes" - returned code  $?'; }
 		;;
 		*)
 			printf_with_color \


### PR DESCRIPTION
This PR fixes inter alia https://github.com/slacka/WoeUSB/issues/283 using the workaround mentioned in https://github.com/slacka/WoeUSB/issues/272.

On Ubuntu 19.04 I was able to create a bootable USB drive with Win10_1909_German_x64.
