### PR TITLE
Update Debian build dependancy

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Maintainer: 林博仁 (Buo-Ren, Lin) <Buo.Ren.Lin@gmail.com>
 Build-Depends: debhelper (>= 9),
                dh-autoreconf,
                git-core,
-               libwxgtk2.8-dev | libwxgtk3.0-dev,
+               libwxgtk2.8-dev | libwxgtk3.0-dev | libwxgtk3.0-gtk3-dev,
                realpath | coreutils (>= 8.23)
 Standards-Version: 4.1.1
 Vcs-Browser: https://github.com/slacka/WoeUSB/


### PR DESCRIPTION
The current 'testing' Debian does not provide `libwxgtk2.8-dev` or `libwxgtk3.0-dev` packages. However, `libwxgtk3.0-gtk3-dev` is available.
This PR adds this build-dependancy package to be installable on 'Debian testing'.

```
$ lsb_release -a
No LSB modules are available.
Distributor ID:	Debian
Description:	Debian GNU/Linux bullseye/sid
Release:	testing
Codename:	bullseye
```

This PR fixes #295.